### PR TITLE
feature/#40 HubRoute 허브 이동경로 생성 로직 구현 - NAVERAPI 연동

### DIFF
--- a/hub/build.gradle
+++ b/hub/build.gradle
@@ -42,6 +42,17 @@ dependencies {
 	runtimeOnly 'org.postgresql:postgresql'
 	runtimeOnly 'com.h2database:h2'
 
+	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
+
+	// Jackson Databind 의존성 (JSON 직렬화 및 역직렬화)
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+	// 추가적으로 Jackson2 JSON 인코더/디코더 설정이 필요한 경우
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+
+	//webclient
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -50,6 +61,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 dependencyManagement {

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/HubApplication.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/HubApplication.java
@@ -2,10 +2,14 @@ package takeoff.logistics_service.msa.hub;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication(
 	scanBasePackages = {"takeoff.logistics_service.msa.common","takeoff.logistics_service.msa.hub"}
 )
+@EnableFeignClients
+@EnableJpaAuditing
 public class HubApplication {
 
 	public static void main(String[] args) {

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/application/dto/HubIdsDto.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/application/dto/HubIdsDto.java
@@ -1,0 +1,14 @@
+package takeoff.logistics_service.msa.hub.hub.application.dto;
+
+import java.util.UUID;
+import lombok.Builder;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 18.
+ */
+@Builder
+public record HubIdsDto(UUID fromHubId,
+                        UUID toHubId) {
+
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/application/dto/request/GetRouteRequestDto.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/application/dto/request/GetRouteRequestDto.java
@@ -1,0 +1,11 @@
+package takeoff.logistics_service.msa.hub.hub.application.dto.request;
+
+import takeoff.logistics_service.msa.hub.hub.application.dto.HubIdsDto;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 18.
+ */
+public record GetRouteRequestDto(HubIdsDto hubIdsDto) {
+
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/application/dto/response/GetRouteResponseDto.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/application/dto/response/GetRouteResponseDto.java
@@ -1,0 +1,28 @@
+package takeoff.logistics_service.msa.hub.hub.application.dto.response;
+
+import java.util.UUID;
+import lombok.Builder;
+import takeoff.logistics_service.msa.hub.hub.domain.entity.Hub;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 15.
+ */
+@Builder
+public record GetRouteResponseDto(UUID hubId,
+                                  String hubName,
+                                  String address,
+                                  Double latitude,
+                                  Double longitude) {
+
+    public static GetRouteResponseDto from(Hub hub) {
+        return GetRouteResponseDto.builder()
+            .hubId(hub.getId())
+            .hubName(hub.getHubName())
+            .address(hub.getHubName())
+            .latitude(hub.getLocation().getLatitude())
+            .longitude(hub.getLocation().getLongitude())
+            .build();
+    }
+
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/application/service/HubService.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/application/service/HubService.java
@@ -1,11 +1,14 @@
 package takeoff.logistics_service.msa.hub.hub.application.service;
 
+import java.util.List;
 import java.util.UUID;
+import takeoff.logistics_service.msa.hub.hub.application.dto.HubIdsDto;
 import takeoff.logistics_service.msa.hub.hub.application.dto.PaginatedResultDto;
 import takeoff.logistics_service.msa.hub.hub.application.dto.request.PatchHubRequestDto;
 import takeoff.logistics_service.msa.hub.hub.application.dto.request.PostHubRequestDto;
 import takeoff.logistics_service.msa.hub.hub.application.dto.request.SearchHubRequestDto;
 import takeoff.logistics_service.msa.hub.hub.application.dto.response.GetHubResponseDto;
+import takeoff.logistics_service.msa.hub.hub.application.dto.response.GetRouteResponseDto;
 import takeoff.logistics_service.msa.hub.hub.application.dto.response.PatchHubResponseDto;
 import takeoff.logistics_service.msa.hub.hub.application.dto.response.PostHubResponseDto;
 import takeoff.logistics_service.msa.hub.hub.application.dto.response.SearchHubResponseDto;
@@ -25,4 +28,6 @@ public interface HubService {
     GetHubResponseDto findByHubId(UUID hubId);
 
     PaginatedResultDto<SearchHubResponseDto> searchHub(SearchHubRequestDto requestDto);
+
+    List<GetRouteResponseDto> findByToHubIdAndFromHubId(HubIdsDto applicationDto);
 }

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/application/service/HubServiceImpl.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/application/service/HubServiceImpl.java
@@ -1,14 +1,17 @@
 package takeoff.logistics_service.msa.hub.hub.application.service;
 
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import takeoff.logistics_service.msa.hub.hub.application.dto.HubIdsDto;
 import takeoff.logistics_service.msa.hub.hub.application.dto.PaginatedResultDto;
 import takeoff.logistics_service.msa.hub.hub.application.dto.request.PatchHubRequestDto;
 import takeoff.logistics_service.msa.hub.hub.application.dto.request.PostHubRequestDto;
 import takeoff.logistics_service.msa.hub.hub.application.dto.request.SearchHubRequestDto;
 import takeoff.logistics_service.msa.hub.hub.application.dto.response.GetHubResponseDto;
+import takeoff.logistics_service.msa.hub.hub.application.dto.response.GetRouteResponseDto;
 import takeoff.logistics_service.msa.hub.hub.application.dto.response.PatchHubResponseDto;
 import takeoff.logistics_service.msa.hub.hub.application.dto.response.PostHubResponseDto;
 import takeoff.logistics_service.msa.hub.hub.application.dto.response.SearchHubResponseDto;
@@ -24,7 +27,7 @@ import takeoff.logistics_service.msa.hub.hub.domain.repository.HubRepository;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class HubServiceImpl implements HubService{
+public class HubServiceImpl implements HubService {
 
     private final HubRepository hubRepository;
 
@@ -54,11 +57,22 @@ public class HubServiceImpl implements HubService{
     }
 
     @Override
+    public List<GetRouteResponseDto> findByToHubIdAndFromHubId(HubIdsDto hubIdsDto) {
+
+        return hubRepository.findByIdIn(
+                List.of(hubIdsDto.toHubId(), hubIdsDto.fromHubId()))
+            .stream()
+            .map(GetRouteResponseDto::from)
+            .toList();
+    }
+
+    @Override
     public void deleteHub(UUID hubId) {
         Hub hub = getHub(hubId);
         //Auth 개발시 수정 예정
         hub.delete(1L);
     }
+
     private Hub getHub(UUID hubId) {
         return hubRepository.findById(hubId)
             .orElseThrow(() -> HubBusinessException.from(HubErrorCode.HUB_NOT_FOUND));

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/domain/entity/Hub.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/domain/entity/Hub.java
@@ -21,6 +21,7 @@ import takeoff.logistics_service.msa.common.domain.BaseEntity;
 @Entity
 @Table(name = "p_hub")
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Hub extends BaseEntity {
 
@@ -38,8 +39,15 @@ public class Hub extends BaseEntity {
         this.hubName = hubName;
     }
 
-    @Builder
+
     private Hub(String hubName, Location location) {
+        this.hubName = hubName;
+        this.location = location;
+    }
+
+    //테스트용 생성자
+    private Hub(UUID id, String hubName, Location location) {
+        this.id = id;
         this.hubName = hubName;
         this.location = location;
     }

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/domain/repository/HubRepository.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/domain/repository/HubRepository.java
@@ -1,5 +1,6 @@
 package takeoff.logistics_service.msa.hub.hub.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import takeoff.logistics_service.msa.hub.hub.domain.entity.Hub;
@@ -18,4 +19,6 @@ public interface HubRepository {
     Optional<Hub> findById(UUID hubId);
 
     PaginatedResult<HubSearchCriteriaResponse> searchHub(HubSearchCriteria hubSearchCriteria);
+
+    List<Hub> findByIdIn(List<UUID> ids);
 }

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/infrastructure/persistence/JpaHubRepository.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/infrastructure/persistence/JpaHubRepository.java
@@ -1,5 +1,6 @@
 package takeoff.logistics_service.msa.hub.hub.infrastructure.persistence;
 
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import takeoff.logistics_service.msa.hub.hub.domain.entity.Hub;
@@ -11,4 +12,5 @@ import takeoff.logistics_service.msa.hub.hub.domain.repository.HubRepository;
  */
 public interface JpaHubRepository extends JpaRepository<Hub, UUID>, HubRepository,JpaHubRepositoryCustom {
 
+    List<Hub> findByIdIn(List<UUID> ids);
 }

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/presentation/dto/HubIds.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/presentation/dto/HubIds.java
@@ -1,0 +1,19 @@
+package takeoff.logistics_service.msa.hub.hub.presentation.dto;
+
+import java.util.UUID;
+import takeoff.logistics_service.msa.hub.hub.application.dto.HubIdsDto;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 18.
+ */
+public record HubIds(UUID fromHubId,
+                     UUID toHubId) {
+
+    public HubIdsDto toApplicationDto() {
+        return HubIdsDto.builder()
+            .fromHubId(fromHubId)
+            .toHubId(toHubId)
+            .build();
+    }
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/presentation/dto/request/GetRouteRequest.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/presentation/dto/request/GetRouteRequest.java
@@ -1,0 +1,12 @@
+package takeoff.logistics_service.msa.hub.hub.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import takeoff.logistics_service.msa.hub.hub.presentation.dto.HubIds;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 18.
+ */
+public record GetRouteRequest(@NotNull HubIds hubIds) {
+
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/presentation/dto/response/GetRouteResponse.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/presentation/dto/response/GetRouteResponse.java
@@ -1,0 +1,28 @@
+package takeoff.logistics_service.msa.hub.hub.presentation.dto.response;
+
+import java.util.UUID;
+import lombok.Builder;
+import takeoff.logistics_service.msa.hub.hub.application.dto.response.GetRouteResponseDto;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 15.
+ */
+@Builder
+public record GetRouteResponse(UUID hubId,
+                               String hubName,
+                               String address,
+                               Double latitude,
+                               Double longitude) {
+
+    public static GetRouteResponse from(GetRouteResponseDto getRouteResponseDto) {
+        return GetRouteResponse.builder()
+            .hubId(getRouteResponseDto.hubId())
+            .hubName(getRouteResponseDto.hubName())
+            .address(getRouteResponseDto.address())
+            .latitude(getRouteResponseDto.latitude())
+            .longitude(getRouteResponseDto.longitude())
+            .build();
+    }
+
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/presentation/internal/HubInternalController.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hub/presentation/internal/HubInternalController.java
@@ -1,13 +1,18 @@
 package takeoff.logistics_service.msa.hub.hub.presentation.internal;
 
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import takeoff.logistics_service.msa.hub.hub.application.service.HubService;
+import takeoff.logistics_service.msa.hub.hub.presentation.dto.HubIds;
 import takeoff.logistics_service.msa.hub.hub.presentation.dto.response.GetHubResponse;
+import takeoff.logistics_service.msa.hub.hub.presentation.dto.response.GetRouteResponse;
 
 /**
  * @author : hanjihoon
@@ -21,8 +26,16 @@ public class HubInternalController {
     private final HubService hubService;
 
     @GetMapping("/{hubId}")
-    public GetHubResponse findByHubId(@PathVariable("hubId")UUID hubId) {
+    public GetHubResponse findByHubId(@PathVariable("hubId") UUID hubId) {
         return GetHubResponse.from(hubService.findByHubId(hubId));
+    }
+
+    @PostMapping("/stopover")
+    public List<GetRouteResponse> findByToHubIdAndFromHubId(@RequestBody HubIds hubIds) {
+        return (hubService.findByToHubIdAndFromHubId(hubIds.toApplicationDto()))
+            .stream()
+            .map(GetRouteResponse::from)
+            .toList();
     }
 
 }

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/DistanceDto.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/DistanceDto.java
@@ -1,0 +1,18 @@
+package takeoff.logistics_service.msa.hub.hubroute.application.dto;
+
+import lombok.Builder;
+import takeoff.logistics_service.msa.hub.hubroute.domain.entity.Distance;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 19.
+ */
+@Builder
+public record DistanceDto(int distance) {
+
+    public static DistanceDto from(Distance distance) {
+        return DistanceDto.builder()
+            .distance(distance.getDistanceKm())
+            .build();
+    }
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/DurationDto.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/DurationDto.java
@@ -1,0 +1,18 @@
+package takeoff.logistics_service.msa.hub.hubroute.application.dto;
+
+import lombok.Builder;
+import takeoff.logistics_service.msa.hub.hubroute.domain.entity.Duration;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 19.
+ */
+@Builder
+public record DurationDto(int duration) {
+
+    public static DurationDto from(Duration duration) {
+        return DurationDto.builder()
+            .duration(duration.getDurationMinutes())
+            .build();
+    }
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/HubRoutes.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/HubRoutes.java
@@ -1,0 +1,10 @@
+package takeoff.logistics_service.msa.hub.hubroute.application.dto;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 18.
+ */
+//허브 이동경로를 리스트로 저장할 1급 컬렉션
+public class HubRoutes {
+
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/client/HubClient.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/client/HubClient.java
@@ -1,0 +1,14 @@
+package takeoff.logistics_service.msa.hub.hubroute.application.dto.client;
+
+import java.util.List;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.request.HubIdsDto;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.response.GetRouteResponseDto;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 18.
+ */
+public interface HubClient {
+    List<GetRouteResponseDto> findByToHubIdAndFromHubId(HubIdsDto hubIdsDto);
+
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/client/NaverRequestClient.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/client/NaverRequestClient.java
@@ -1,0 +1,17 @@
+package takeoff.logistics_service.msa.hub.hubroute.application.dto.client;
+
+import java.util.List;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.response.GetHubRouteNaverResponseDto;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.response.GetRouteResponseDto;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 19.
+ */
+@Component
+public interface NaverRequestClient {
+
+    Mono<GetHubRouteNaverResponseDto> sendRequestToNaver(List<GetRouteResponseDto> responseToHub);
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/request/HubIdsDto.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/request/HubIdsDto.java
@@ -1,0 +1,19 @@
+package takeoff.logistics_service.msa.hub.hubroute.application.dto.request;
+
+import java.util.UUID;
+import lombok.Builder;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 18.
+ */
+@Builder
+public record HubIdsDto(UUID toHubId,
+                        UUID fromHubId) {
+    public static HubIdsDto from(PostHubRouteRequestDto requestDto) {
+        return HubIdsDto.builder()
+            .toHubId(requestDto.toHubId())
+            .fromHubId(requestDto.fromHubId())
+            .build();
+    }
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/request/PostHubRouteRequestDto.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/request/PostHubRouteRequestDto.java
@@ -1,11 +1,13 @@
 package takeoff.logistics_service.msa.hub.hubroute.application.dto.request;
 
 import java.util.UUID;
+import lombok.Builder;
 
 /**
  * @author : hanjihoon
  * @Date : 2025. 03. 15.
  */
+@Builder
 public record PostHubRouteRequestDto(UUID fromHubId,
                                      UUID toHubId) {
 

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/response/GetHubRouteNaverResponseDto.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/response/GetHubRouteNaverResponseDto.java
@@ -1,0 +1,26 @@
+package takeoff.logistics_service.msa.hub.hubroute.application.dto.response;
+
+import lombok.Builder;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.request.PostHubRouteRequestDto;
+import takeoff.logistics_service.msa.hub.hubroute.domain.entity.Distance;
+import takeoff.logistics_service.msa.hub.hubroute.domain.entity.Duration;
+import takeoff.logistics_service.msa.hub.hubroute.domain.entity.HubRoute;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 19.
+ */
+@Builder
+public record GetHubRouteNaverResponseDto(Integer distance,
+                                          Integer duration) {
+
+    public static HubRoute toEntity(GetHubRouteNaverResponseDto getHubRouteNaverResponseDto,
+        PostHubRouteRequestDto postHubRouteRequestDto) {
+        return HubRoute.builder()
+            .toHubId(postHubRouteRequestDto.toHubId())
+            .fromHubId(postHubRouteRequestDto.fromHubId())
+            .distance(Distance.create(getHubRouteNaverResponseDto.distance()))
+            .duration(Duration.create(getHubRouteNaverResponseDto.duration()))
+            .build();
+    }
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/response/GetHubRouteNaverResponseDto.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/response/GetHubRouteNaverResponseDto.java
@@ -14,13 +14,13 @@ import takeoff.logistics_service.msa.hub.hubroute.domain.entity.HubRoute;
 public record GetHubRouteNaverResponseDto(Integer distance,
                                           Integer duration) {
 
-    public static HubRoute toEntity(GetHubRouteNaverResponseDto getHubRouteNaverResponseDto,
+    public HubRoute toEntity(
         PostHubRouteRequestDto postHubRouteRequestDto) {
         return HubRoute.builder()
             .toHubId(postHubRouteRequestDto.toHubId())
             .fromHubId(postHubRouteRequestDto.fromHubId())
-            .distance(Distance.create(getHubRouteNaverResponseDto.distance()))
-            .duration(Duration.create(getHubRouteNaverResponseDto.duration()))
+            .distance(Distance.create(distance()))
+            .duration(Duration.create(duration()))
             .build();
     }
 }

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/response/GetRouteResponseDto.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/response/GetRouteResponseDto.java
@@ -1,0 +1,17 @@
+package takeoff.logistics_service.msa.hub.hubroute.application.dto.response;
+
+import java.util.UUID;
+import lombok.Builder;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 19.
+ */
+@Builder
+public record GetRouteResponseDto(UUID hubId,
+                                  String hubName,
+                                  String address,
+                                  Double latitude,
+                                  Double longitude) {
+
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/response/PostHubRouteResponseDto.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/dto/response/PostHubRouteResponseDto.java
@@ -1,15 +1,27 @@
 package takeoff.logistics_service.msa.hub.hubroute.application.dto.response;
 
 import java.util.UUID;
-import takeoff.logistics_service.msa.hub.hubroute.domain.entity.Distance;
-import takeoff.logistics_service.msa.hub.hubroute.domain.entity.Duration;
+import lombok.Builder;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.DistanceDto;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.DurationDto;
+import takeoff.logistics_service.msa.hub.hubroute.domain.entity.HubRoute;
 
 /**
  * @author : hanjihoon
  * @Date : 2025. 03. 15.
  */
+@Builder
 public record PostHubRouteResponseDto(UUID hubRouteId,
-                                      Distance distance,
-                                      Duration duration) {
+                                      DistanceDto distanceDto,
+                                      DurationDto durationDto) {
+
+    public static PostHubRouteResponseDto from(HubRoute hubRoute) {
+        return PostHubRouteResponseDto.builder()
+            .hubRouteId(hubRoute.getId())
+            .distanceDto(DistanceDto.from(hubRoute.getDistance()))
+            .durationDto(DurationDto.from(hubRoute.getDuration()))
+            .build();
+    }
+
 
 }

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/exception/HubRouteBusinessException.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/exception/HubRouteBusinessException.java
@@ -1,0 +1,13 @@
+package takeoff.logistics_service.msa.hub.hubroute.application.exception;
+
+import lombok.Getter;
+import takeoff.logistics_service.msa.common.exception.BusinessException;
+import takeoff.logistics_service.msa.common.exception.code.ErrorCode;
+
+@Getter
+public class HubRouteBusinessException extends BusinessException {
+
+	private HubRouteBusinessException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/exception/HubRouteErrorCode.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/exception/HubRouteErrorCode.java
@@ -1,0 +1,23 @@
+package takeoff.logistics_service.msa.hub.hubroute.application.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import takeoff.logistics_service.msa.common.exception.code.ErrorCode;
+
+@Getter
+public enum HubRouteErrorCode implements ErrorCode {
+
+	INVALID_HUB_ROUTE_REQUEST("HUB_ROUTE_001", "요청한 허브 ID가 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+	NAVER_ERROR("HUB_ROUTE_005", "NAVER API 답을 받아 올 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+	HUB_ROUTE_NOT_FOUND("HUB_ROUTE_004", "존재하지 않는 허브 경로 입니다.", HttpStatus.NOT_FOUND);
+
+	private final String code;
+	private final String message;
+	private final int status;
+
+	HubRouteErrorCode(String code, String message, HttpStatus status) {
+		this.code = code;
+		this.message = message;
+		this.status = status.value();
+	}
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/service/HubRouteService.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/service/HubRouteService.java
@@ -1,8 +1,10 @@
 package takeoff.logistics_service.msa.hub.hubroute.application.service;
 
 import java.util.UUID;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.request.PostHubRouteRequestDto;
 import takeoff.logistics_service.msa.hub.hubroute.application.dto.request.PutHubRouteRequestDto;
 import takeoff.logistics_service.msa.hub.hubroute.application.dto.response.GetHubRouteResponseDto;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.response.PostHubRouteResponseDto;
 import takeoff.logistics_service.msa.hub.hubroute.application.dto.response.PutHubRouteResponseDto;
 
 /**
@@ -15,7 +17,7 @@ public interface HubRouteService {
 
     PutHubRouteResponseDto updateHubRoute(UUID hubRouteId, PutHubRouteRequestDto requestDto);
 
-    void deleteHubRoute(UUID hubRouteId);
+    void deleteHubRoute(UUID hubRouteId, Long userId);
 
-//    List<PostHubRouteResponseDto> createHubRoute(PostHubRouteRequestDto requestDto);
+    PostHubRouteResponseDto createHubRoute(PostHubRouteRequestDto requestDto);
 }

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/service/HubRouteServiceImpl.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/service/HubRouteServiceImpl.java
@@ -1,12 +1,23 @@
 package takeoff.logistics_service.msa.hub.hubroute.application.service;
 
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.client.HubClient;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.client.NaverRequestClient;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.request.HubIdsDto;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.request.PostHubRouteRequestDto;
 import takeoff.logistics_service.msa.hub.hubroute.application.dto.request.PutHubRouteRequestDto;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.response.GetHubRouteNaverResponseDto;
 import takeoff.logistics_service.msa.hub.hubroute.application.dto.response.GetHubRouteResponseDto;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.response.GetRouteResponseDto;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.response.PostHubRouteResponseDto;
 import takeoff.logistics_service.msa.hub.hubroute.application.dto.response.PutHubRouteResponseDto;
+import takeoff.logistics_service.msa.hub.hubroute.application.exception.HubRouteBusinessException;
+import takeoff.logistics_service.msa.hub.hubroute.application.exception.HubRouteErrorCode;
 import takeoff.logistics_service.msa.hub.hubroute.domain.entity.HubRoute;
 import takeoff.logistics_service.msa.hub.hubroute.domain.repository.HubRouteRepository;
 
@@ -17,9 +28,33 @@ import takeoff.logistics_service.msa.hub.hubroute.domain.repository.HubRouteRepo
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class HubRouteServiceImpl implements HubRouteService{
 
     private final HubRouteRepository hubRouteRepository;
+    private final HubClient hubClient;
+    private final NaverRequestClient naverRequestClient;
+
+
+    @Override
+    public PostHubRouteResponseDto createHubRoute(PostHubRouteRequestDto requestDto) {
+        log.info("----------------------");
+        List<GetRouteResponseDto> responseToHub = hubClient.findByToHubIdAndFromHubId(
+            HubIdsDto.from(requestDto));
+
+        GetHubRouteNaverResponseDto result = naverRequestClient.sendRequestToNaver(responseToHub)
+            .onErrorMap(error -> {
+                log.error("NaverAPI 응답을 받을 수 없습니다.", error);
+                return HubRouteBusinessException.from(HubRouteErrorCode.NAVER_ERROR);
+            })
+            .block();
+
+        HubRoute hubRoute = GetHubRouteNaverResponseDto.toEntity(result, requestDto);
+        HubRoute savedHubRoute = hubRouteRepository.save(hubRoute);
+
+        return PostHubRouteResponseDto.from(savedHubRoute);
+
+    }
 
     @Override
     @Transactional(readOnly = true)
@@ -42,22 +77,15 @@ public class HubRouteServiceImpl implements HubRouteService{
         return PutHubRouteResponseDto.from(hubRoute);
     }
 
-    //baseEntity 생성후 수정
     @Override
-    public void deleteHubRoute(UUID hubRouteId) {
-        getHubRoute(hubRouteId);
-
+    public void deleteHubRoute(UUID hubRouteId, Long userId) {
+        HubRoute hubRoute = getHubRoute(hubRouteId);
+        hubRoute.delete(userId);
     }
-
-    //허브 이동경로 생성은 알고리즘 때문에 고민 좀 더 해보고 작성하겠습니다..
-//    @Override
-//    public List<PostHubRouteResponseDto> createHubRoute(PostHubRouteRequestDto requestDto) {
-//
-//    }
 
     private HubRoute getHubRoute(UUID hubRouteId) {
         return hubRouteRepository.findById(hubRouteId)
-            .orElseThrow(() -> new IllegalArgumentException("찾을 수 없는 허브 이동경로 입니다."));
+            .orElseThrow(() -> HubRouteBusinessException.from(HubRouteErrorCode.INVALID_HUB_ROUTE_REQUEST));
     }
 
 

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/service/HubRouteServiceImpl.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/application/service/HubRouteServiceImpl.java
@@ -49,7 +49,8 @@ public class HubRouteServiceImpl implements HubRouteService{
             })
             .block();
 
-        HubRoute hubRoute = GetHubRouteNaverResponseDto.toEntity(result, requestDto);
+
+        HubRoute hubRoute = result.toEntity(requestDto);
         HubRoute savedHubRoute = hubRouteRepository.save(hubRoute);
 
         return PostHubRouteResponseDto.from(savedHubRoute);

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/domain/entity/HubRoute.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/domain/entity/HubRoute.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import takeoff.logistics_service.msa.common.domain.BaseEntity;
 
 /**
  * @author : hanjihoon
@@ -19,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "p_hubRoute")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class HubRoute {
+public class HubRoute extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
@@ -43,5 +45,11 @@ public class HubRoute {
         Duration.create(minutes);
     }
 
-
+    @Builder
+    private HubRoute(UUID fromHubId, UUID toHubId, Distance distance, Duration duration) {
+        this.fromHubId = fromHubId;
+        this.toHubId = toHubId;
+        this.distance = distance;
+        this.duration = duration;
+    }
 }

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/domain/repository/HubRouteRepository.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/domain/repository/HubRouteRepository.java
@@ -11,4 +11,6 @@ import takeoff.logistics_service.msa.hub.hubroute.domain.entity.HubRoute;
 public interface HubRouteRepository {
 
     Optional<HubRoute> findById(UUID hubRouteId);
+
+    HubRoute save(HubRoute hubRoute);
 }

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/client/external/NaverApiAdapter.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/client/external/NaverApiAdapter.java
@@ -1,0 +1,12 @@
+package takeoff.logistics_service.msa.hub.hubroute.infrastructure.client.external;
+
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.client.NaverRequestClient;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 19.
+ */
+
+public interface NaverApiAdapter extends NaverRequestClient {
+
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/client/external/NaverApiResponse.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/client/external/NaverApiResponse.java
@@ -1,0 +1,22 @@
+package takeoff.logistics_service.msa.hub.hubroute.infrastructure.client.external;
+
+import java.util.List;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 19.
+ */
+public record NaverApiResponse(int code, String message, Route route) {
+}
+
+record Route(List<Traoptimal> traoptimal) {}
+
+record Traoptimal(Summary summary, List<Guide> guides) {}
+
+record Summary(Start start, Goal goal, int distance, int duration) {}
+
+record Guide(int pointIndex, int distance, int duration) {}
+
+record Start(List<Double> location) {}
+
+record Goal(List<Double> location, int dir) {}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/client/external/NaverDirectionWebClient.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/client/external/NaverDirectionWebClient.java
@@ -72,8 +72,9 @@ public class NaverDirectionWebClient implements NaverApiAdapter{
         return getResult(response);
     }
     private static GetHubRouteNaverResponse getResult(NaverApiResponse response) {
-        int totalDistance = response.route().traoptimal().get(0).summary().distance();
-        int totalDuration = response.route().traoptimal().get(0).summary().duration();
+        int totalDistance = response.route().traoptimal().get(0).summary().distance() / 1000;
+        int totalDuration = response.route().traoptimal().get(0).summary().duration() / 60;
+
 
         return new GetHubRouteNaverResponse(totalDistance, totalDuration);
     }

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/client/external/NaverDirectionWebClient.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/client/external/NaverDirectionWebClient.java
@@ -1,0 +1,83 @@
+package takeoff.logistics_service.msa.hub.hubroute.infrastructure.client.external;
+
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.response.GetHubRouteNaverResponseDto;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.response.GetRouteResponseDto;
+import takeoff.logistics_service.msa.hub.hubroute.application.exception.HubRouteBusinessException;
+import takeoff.logistics_service.msa.hub.hubroute.application.exception.HubRouteErrorCode;
+import takeoff.logistics_service.msa.hub.hubroute.infrastructure.dto.response.GetHubRouteNaverResponse;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 19.
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class NaverDirectionWebClient implements NaverApiAdapter{
+
+    private final WebClient webClient;
+
+    @Value("${naver.id}")
+    private String apiId;
+    @Value("${naver.key}")
+    private String apiKey;
+    @Value("${naver.url}")
+    private String naverUrl;
+
+    private static final String HEADER_ID = "X-NCP-APIGW-API-KEY-ID";
+    private static final String HEADER_KEY = "X-NCP-APIGW-API-KEY";
+
+    public Mono<GetHubRouteNaverResponseDto> sendRequestToNaver(List<GetRouteResponseDto> responseToHub) {
+        if (responseToHub == null || responseToHub.size() < 2) {
+            return Mono.error(HubRouteBusinessException.from(HubRouteErrorCode.HUB_ROUTE_NOT_FOUND));
+        }
+
+        String requestUrl = buildRequestUrl(responseToHub.get(0), responseToHub.get(responseToHub.size() - 1));
+
+        return webClient.mutate()
+            .build().method(HttpMethod.GET)
+            .uri(requestUrl)
+            .headers(httpHeaders -> {
+                httpHeaders.set(HEADER_ID, apiId);
+                httpHeaders.set(HEADER_KEY,apiKey);})
+            .retrieve()
+            .bodyToMono(NaverApiResponse.class)
+            .map(this::convertToHubRouteResponse)
+            .map(GetHubRouteNaverResponse::from);
+
+
+    }
+
+    private String buildRequestUrl(GetRouteResponseDto startHub, GetRouteResponseDto goalHub) {
+        return UriComponentsBuilder.fromUriString(naverUrl)
+            .queryParam("goal", goalHub.longitude() + "," + goalHub.latitude())
+            .queryParam("start", startHub.longitude() + "," + startHub.latitude())
+            .toUriString();
+    }
+
+    private GetHubRouteNaverResponse convertToHubRouteResponse(NaverApiResponse response) {
+        if (response == null || response.route() == null || response.route().traoptimal().isEmpty()) {
+            throw HubRouteBusinessException.from(HubRouteErrorCode.NAVER_ERROR);
+        }
+        return getResult(response);
+    }
+    private static GetHubRouteNaverResponse getResult(NaverApiResponse response) {
+        int totalDistance = response.route().traoptimal().get(0).summary().distance();
+        int totalDuration = response.route().traoptimal().get(0).summary().duration();
+
+        return new GetHubRouteNaverResponse(totalDistance, totalDuration);
+    }
+
+
+
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/client/feign/FeignHubClient.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/client/feign/FeignHubClient.java
@@ -1,0 +1,20 @@
+package takeoff.logistics_service.msa.hub.hubroute.infrastructure.client.feign;
+
+import java.util.List;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import takeoff.logistics_service.msa.hub.hubroute.infrastructure.dto.request.HubIds;
+import takeoff.logistics_service.msa.hub.hubroute.infrastructure.dto.response.GetRouteResponse;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 18.
+ */
+@FeignClient(name = "hub", url = "http://localhost:19042")
+public interface FeignHubClient {
+
+    @PostMapping("/api/v1/app/hubs/stopover")
+    List<GetRouteResponse> findByToHubIdAndFromHubId(@RequestBody HubIds hubIds);
+
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/client/feign/FeignHubClientImpl.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/client/feign/FeignHubClientImpl.java
@@ -1,0 +1,50 @@
+package takeoff.logistics_service.msa.hub.hubroute.infrastructure.client.feign;
+
+import feign.FeignException.FeignClientException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import takeoff.logistics_service.msa.common.exception.BusinessException;
+import takeoff.logistics_service.msa.common.exception.code.CommonErrorCode;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.client.HubClient;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.request.HubIdsDto;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.response.GetRouteResponseDto;
+import takeoff.logistics_service.msa.hub.hubroute.application.exception.HubRouteBusinessException;
+import takeoff.logistics_service.msa.hub.hubroute.application.exception.HubRouteErrorCode;
+import takeoff.logistics_service.msa.hub.hubroute.infrastructure.dto.request.HubIds;
+import takeoff.logistics_service.msa.hub.hubroute.infrastructure.dto.response.GetRouteResponse;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 18.
+ */
+@Component
+@RequiredArgsConstructor
+public class FeignHubClientImpl implements HubClient {
+
+    private final FeignHubClient feignHubClient;
+
+    @Override
+    public List<GetRouteResponseDto> findByToHubIdAndFromHubId(HubIdsDto hubIdsDto) {
+
+        try {
+            return feignHubClient.findByToHubIdAndFromHubId(HubIds.from(hubIdsDto))
+                .stream()
+                .map(GetRouteResponse::from)
+                .toList();
+        } catch (FeignClientException e) {
+            throw handleFeignException(e);
+        }
+    }
+
+    private BusinessException handleFeignException(FeignClientException e) {
+        if (e.status() == HttpStatus.BAD_REQUEST.value()) {
+            return HubRouteBusinessException.from(HubRouteErrorCode.INVALID_HUB_ROUTE_REQUEST);
+        } else if (e.status() == HttpStatus.NOT_FOUND.value()) {
+            return HubRouteBusinessException.from(HubRouteErrorCode.HUB_ROUTE_NOT_FOUND);
+        } else {
+            return HubRouteBusinessException.from(CommonErrorCode.BAD_GATEWAY);
+        }
+    }
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/config/WebClientConfig.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/config/WebClientConfig.java
@@ -1,0 +1,51 @@
+package takeoff.logistics_service.msa.hub.hubroute.infrastructure.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.http.codec.LoggingCodecSupport;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 16.
+ */
+@Configuration
+@Slf4j
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+
+        //응답 데이터가 기본 값이 256KB인데 큰 JSON 데이터를 받을 것을 고려해 확장(30MB)
+        ExchangeStrategies exchangeStrategies = ExchangeStrategies.builder()
+            .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(1024*1024*30))
+            .build();
+        //로깅을 위한 설정 아래 설정으로 인해 본문 데이터도 로깅 가능
+        exchangeStrategies
+            .messageWriters().stream()
+            .filter(LoggingCodecSupport.class::isInstance)
+            .forEach(writer -> ((LoggingCodecSupport)writer).setEnableLoggingRequestDetails(true));
+
+        return WebClient.builder()
+            .clientConnector(
+                new ReactorClientHttpConnector(
+                    HttpClient
+                        .create()
+                        //서버와 연결을 2분을 기다리고 응답은 최대 3분까지 기다리는 로직
+                        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 120_000)
+                        .doOnConnected(conn ->
+                                conn.addHandlerLast(new ReadTimeoutHandler(180))
+                                    .addHandlerLast(new WriteTimeoutHandler(180))
+                                )
+                        )
+                )
+            .build();
+    }
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/dto/request/GetRouteNaverRequestDto.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/dto/request/GetRouteNaverRequestDto.java
@@ -1,0 +1,15 @@
+package takeoff.logistics_service.msa.hub.hubroute.infrastructure.dto.request;
+
+import java.util.UUID;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 19.
+ */
+public record GetRouteNaverRequestDto(UUID hubId,
+                                      String hubName,
+                                      String address,
+                                      Double latitude,
+                                      Double longitude) {
+
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/dto/request/HubIds.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/dto/request/HubIds.java
@@ -1,0 +1,21 @@
+package takeoff.logistics_service.msa.hub.hubroute.infrastructure.dto.request;
+
+import java.util.UUID;
+import lombok.Builder;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.request.HubIdsDto;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 18.
+ */
+@Builder
+public record HubIds(UUID toHubId,
+                     UUID fromHubId) {
+    public static HubIds from(HubIdsDto hubIdsDto) {
+        return HubIds.builder()
+            .toHubId(hubIdsDto.toHubId())
+            .fromHubId(hubIdsDto.fromHubId())
+            .build();
+    }
+
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/dto/response/GetHubRouteNaverResponse.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/dto/response/GetHubRouteNaverResponse.java
@@ -1,0 +1,19 @@
+package takeoff.logistics_service.msa.hub.hubroute.infrastructure.dto.response;
+
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.response.GetHubRouteNaverResponseDto;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 19.
+ */
+public record GetHubRouteNaverResponse(Integer distance,
+                                       Integer duration) {
+
+    public static GetHubRouteNaverResponseDto from(GetHubRouteNaverResponse getHubRouteNaverResponse) {
+        return GetHubRouteNaverResponseDto.builder()
+            .distance(getHubRouteNaverResponse.distance())
+            .duration(getHubRouteNaverResponse.duration())
+            .build();
+    }
+
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/dto/response/GetRouteResponse.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/infrastructure/dto/response/GetRouteResponse.java
@@ -1,0 +1,26 @@
+package takeoff.logistics_service.msa.hub.hubroute.infrastructure.dto.response;
+
+import java.util.UUID;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.response.GetRouteResponseDto;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 18.
+ */
+public record GetRouteResponse(UUID hubId,
+                               String hubName,
+                               String address,
+                               Double latitude,
+                               Double longitude) {
+
+    public GetRouteResponseDto from() {
+        return GetRouteResponseDto.builder()
+            .hubId(hubId)
+            .hubName(hubName)
+            .address(address)
+            .latitude(latitude)
+            .longitude(longitude)
+            .build();
+    }
+
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/presentation/dto/DistanceApi.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/presentation/dto/DistanceApi.java
@@ -1,0 +1,18 @@
+package takeoff.logistics_service.msa.hub.hubroute.presentation.dto;
+
+import lombok.Builder;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.DistanceDto;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 19.
+ */
+@Builder
+public record DistanceApi(int distance) {
+
+    public static DistanceApi from(DistanceDto distanceDto) {
+        return DistanceApi.builder()
+            .distance(distanceDto.distance())
+            .build();
+    }
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/presentation/dto/DurationApi.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/presentation/dto/DurationApi.java
@@ -1,0 +1,18 @@
+package takeoff.logistics_service.msa.hub.hubroute.presentation.dto;
+
+import lombok.Builder;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.DurationDto;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 19.
+ */
+@Builder
+public record DurationApi(int duration) {
+
+    public static DurationApi from(DurationDto durationDto) {
+        return DurationApi.builder()
+            .duration(durationDto.duration())
+            .build();
+    }
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/presentation/dto/HubRouteInfo.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/presentation/dto/HubRouteInfo.java
@@ -1,0 +1,14 @@
+package takeoff.logistics_service.msa.hub.hubroute.presentation.dto;
+
+import lombok.Builder;
+import takeoff.logistics_service.msa.hub.hubroute.domain.entity.Distance;
+import takeoff.logistics_service.msa.hub.hubroute.domain.entity.Duration;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 19.
+ */
+@Builder
+public record HubRouteInfo(Distance distance,
+                           Duration duration) {
+}

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/presentation/dto/request/PostHubRouteRequest.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/presentation/dto/request/PostHubRouteRequest.java
@@ -1,6 +1,7 @@
 package takeoff.logistics_service.msa.hub.hubroute.presentation.dto.request;
 
 import java.util.UUID;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.request.PostHubRouteRequestDto;
 
 /**
  * @author : hanjihoon
@@ -8,5 +9,12 @@ import java.util.UUID;
  */
 public record PostHubRouteRequest(UUID fromHubId,
                                   UUID toHubId) {
+
+    public PostHubRouteRequestDto toApplication() {
+        return PostHubRouteRequestDto.builder()
+            .fromHubId(fromHubId)
+            .toHubId(toHubId)
+            .build();
+    }
 
 }

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/presentation/dto/response/PostHubRouteResponse.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/presentation/dto/response/PostHubRouteResponse.java
@@ -1,15 +1,26 @@
 package takeoff.logistics_service.msa.hub.hubroute.presentation.dto.response;
 
 import java.util.UUID;
-import takeoff.logistics_service.msa.hub.hubroute.domain.entity.Distance;
-import takeoff.logistics_service.msa.hub.hubroute.domain.entity.Duration;
+import lombok.Builder;
+import takeoff.logistics_service.msa.hub.hubroute.application.dto.response.PostHubRouteResponseDto;
+import takeoff.logistics_service.msa.hub.hubroute.presentation.dto.DistanceApi;
+import takeoff.logistics_service.msa.hub.hubroute.presentation.dto.DurationApi;
 
 /**
  * @author : hanjihoon
  * @Date : 2025. 03. 15.
  */
+@Builder
 public record PostHubRouteResponse(UUID hubRouteId,
-                                   Distance distance,
-                                   Duration duration) {
+                                   DistanceApi distanceApi,
+                                   DurationApi durationApi) {
+
+    public static PostHubRouteResponse from(PostHubRouteResponseDto responseDto) {
+        return PostHubRouteResponse.builder()
+            .hubRouteId(responseDto.hubRouteId())
+            .distanceApi(DistanceApi.from(responseDto.distanceDto()))
+            .durationApi(DurationApi.from(responseDto.durationDto()))
+            .build();
+    }
 
 }

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/presentation/dto/response/PutHubRouteResponse.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/presentation/dto/response/PutHubRouteResponse.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 import takeoff.logistics_service.msa.hub.hubroute.application.dto.response.PutHubRouteResponseDto;
 import takeoff.logistics_service.msa.hub.hubroute.domain.entity.Distance;
 import takeoff.logistics_service.msa.hub.hubroute.domain.entity.Duration;
-import takeoff.logistics_service.msa.hub.hubroute.domain.entity.HubRoute;
 
 /**
  * @author : hanjihoon

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/presentation/external/HubRouteExternalController.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/presentation/external/HubRouteExternalController.java
@@ -37,8 +37,8 @@ public class HubRouteExternalController {
         return ResponseEntity.ok(PutHubRouteResponse.from(hubRouteService.updateHubRoute(hubRouteId, requestDto.toApplicationDto())));
     }
     @DeleteMapping("/{hubRouteId}")
-    public ResponseEntity<Void> deleteHubRoute(@PathVariable("hubRouteId")UUID hubRouteId) {
-        hubRouteService.deleteHubRoute(hubRouteId);
+    public ResponseEntity<Void> deleteHubRoute(@PathVariable("hubRouteId")UUID hubRouteId, Long userId) {
+        hubRouteService.deleteHubRoute(hubRouteId,userId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/presentation/internal/HubRouteInternalController.java
+++ b/hub/src/main/java/takeoff/logistics_service/msa/hub/hubroute/presentation/internal/HubRouteInternalController.java
@@ -1,9 +1,13 @@
 package takeoff.logistics_service.msa.hub.hubroute.presentation.internal;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import takeoff.logistics_service.msa.hub.hubroute.application.service.HubRouteService;
+import takeoff.logistics_service.msa.hub.hubroute.presentation.dto.request.PostHubRouteRequest;
+import takeoff.logistics_service.msa.hub.hubroute.presentation.dto.response.PostHubRouteResponse;
 
 /**
  * @author : hanjihoon
@@ -16,9 +20,9 @@ public class HubRouteInternalController {
 
     private final HubRouteService hubRouteService;
 
-//    @PostMapping
-//    public List<PostHubRouteResponseDto> createHubRoute(@RequestBody PostHubRouteRequestDto requestDto) {
-//        return hubRouteService.createHubRoute(requestDto);
-//    }
+    @PostMapping
+    public PostHubRouteResponse createHubRoute(@RequestBody PostHubRouteRequest request) {
+        return PostHubRouteResponse.from(hubRouteService.createHubRoute(request.toApplication()));
+    }
 
 }

--- a/hub/src/main/resources/application-test.yml
+++ b/hub/src/main/resources/application-test.yml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    import: optional:file:.env.test[.properties]
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:~/takeoff
+    username: admin
+    password:
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        spring.jpa.open-in-view: false
+        format_sql: true
+        default_batch_fetch_size: 10

--- a/hub/src/main/resources/application.yml
+++ b/hub/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: optional:file:.env[.properties]
   application:
     name: hub-service
   datasource:
@@ -9,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true
@@ -38,3 +40,8 @@ management:
 
 server:
   port: 19042
+
+NAVER:
+  ID: ${NAVER_Client_ID}
+  KEY: ${NAVER_Secret_KEY}
+  URL: ${NAVER_URL}

--- a/hub/src/test/java/takeoff/logistics_service/msa/hub/http/Hub.http
+++ b/hub/src/test/java/takeoff/logistics_service/msa/hub/http/Hub.http
@@ -1,0 +1,235 @@
+POST http://localhost:19042/api/v1/hubs
+Content-Type: application/json
+
+{
+  "hubName": "서울특별시 센터",
+  "locationApi": {
+    "address": "서울특별시 송파구 송파대로 55",
+    "latitude": 37.514219,
+    "longitude": 127.112628
+  }
+}
+
+####
+
+POST http://localhost:19042/api/v1/hubs
+Content-Type: application/json
+
+{
+  "hubName": "경기 북부 센터",
+  "locationApi": {
+    "address": "경기도 고양시 덕양구 권율대로 570",
+    "latitude": 37.649621,
+    "longitude": 126.835836
+  }
+}
+
+###
+
+POST http://localhost:19042/api/v1/hubs
+Content-Type: application/json
+
+{
+  "hubName": "경기 남부 센터",
+  "locationApi": {
+    "address": "경기도 이천시 덕평로 257-21",
+    "latitude": 37.210106,
+    "longitude": 127.435027
+  }
+}
+
+###
+
+POST http://localhost:19042/api/v1/hubs
+Content-Type: application/json
+
+{
+  "hubName": "부산광역시 센터",
+  "locationApi": {
+    "address": "부산 동구 중앙대로 206",
+    "latitude": 35.134183,
+    "longitude": 129.056081
+  }
+}
+
+###
+
+POST http://localhost:19042/api/v1/hubs
+Content-Type: application/json
+
+{
+  "hubName": "대구광역시 센터",
+  "locationApi": {
+    "address": "대구 북구 태평로 161",
+    "latitude": 35.881539,
+    "longitude": 128.581292
+  }
+}
+
+###
+
+POST http://localhost:19042/api/v1/hubs
+Content-Type: application/json
+
+{
+  "hubName": "인천광역시 센터",
+  "locationApi": {
+    "address": "인천 남동구 정각로 29",
+    "latitude": 37.447336,
+    "longitude": 126.731539
+  }
+}
+
+###
+
+POST http://localhost:19042/api/v1/hubs
+Content-Type: application/json
+
+{
+  "hubName": "광주광역시 센터",
+  "locationApi": {
+    "address": "광주 서구 내방로 111",
+    "latitude": 35.153206,
+    "longitude": 126.888950
+  }
+}
+
+###
+
+POST http://localhost:19042/api/v1/hubs
+Content-Type: application/json
+
+{
+  "hubName": "대전광역시 센터",
+  "locationApi": {
+    "address": "대전 서구 둔산로 100",
+    "latitude": 36.351524,
+    "longitude": 127.378144
+  }
+}
+
+###
+
+POST http://localhost:19042/api/v1/hubs
+Content-Type: application/json
+
+{
+  "hubName": "울산광역시 센터",
+  "locationApi": {
+    "address": "울산 남구 중앙로 201",
+    "latitude": 35.543601,
+    "longitude": 129.320901
+  }
+}
+
+###
+
+POST http://localhost:19042/api/v1/hubs
+Content-Type: application/json
+
+{
+  "hubName": "세종특별자치시 센터",
+  "locationApi": {
+    "address": "세종특별자치시 한누리대로 2130",
+    "latitude": 36.480838,
+    "longitude": 127.289509
+  }
+}
+
+###
+
+POST http://localhost:19042/api/v1/hubs
+Content-Type: application/json
+
+{
+  "hubName": "강원특별자치도 센터",
+  "locationApi": {
+    "address": "강원특별자치도 춘천시 중앙로 1",
+    "latitude": 37.881221,
+    "longitude": 127.729694
+  }
+}
+
+###
+
+POST http://localhost:19042/api/v1/hubs
+Content-Type: application/json
+
+{
+  "hubName": "충청북도 센터",
+  "locationApi": {
+    "address": "충북 청주시 상당구 상당로 82",
+    "latitude": 36.636993,
+    "longitude": 127.489479
+  }
+}
+
+###
+
+POST http://localhost:19042/api/v1/hubs
+Content-Type: application/json
+
+{
+  "hubName": "충청남도 센터",
+  "locationApi": {
+    "address": "충남 홍성군 홍북읍 충남대로 21",
+    "latitude": 36.658826,
+    "longitude": 126.660759
+  }
+}
+
+###
+
+POST http://localhost:19042/api/v1/hubs
+Content-Type: application/json
+
+{
+  "hubName": "전북특별자치도 센터",
+  "locationApi": {
+    "address": "전북특별자치도 전주시 완산구 효자로 225",
+    "latitude": 35.824193,
+    "longitude": 127.114653
+  }
+}
+
+###
+
+POST http://localhost:19042/api/v1/hubs
+Content-Type: application/json
+
+{
+  "hubName": "전라남도 센터",
+  "locationApi": {
+    "address": "전남 무안군 삼향읍 오룡길 1",
+    "latitude": 34.813878,
+    "longitude": 126.464678
+  }
+}
+
+###
+
+POST http://localhost:19042/api/v1/hubs
+Content-Type: application/json
+
+{
+  "hubName": "경상북도 센터",
+  "locationApi": {
+    "address": "경북 안동시 풍천면 도청대로 455",
+    "latitude": 36.574028,
+    "longitude": 128.506568
+  }
+}
+
+###
+
+POST http://localhost:19042/api/v1/hubs
+Content-Type: application/json
+
+{
+  "hubName": "경상남도 센터",
+  "locationApi": {
+    "address": "경남 창원시 의창구 중앙대로 300",
+    "latitude": 35.241687,
+    "longitude": 128.680407
+  }
+}

--- a/hub/src/test/java/takeoff/logistics_service/msa/hub/http/HubRoute.http
+++ b/hub/src/test/java/takeoff/logistics_service/msa/hub/http/HubRoute.http
@@ -1,0 +1,14 @@
+### 네이버 map direction
+GET https://naveropenapi.apigw.ntruss.com/map-direction/v1/driving?goal=126.835836,37.649621&start=127.112628,37.514219
+X-NCP-APIGW-API-KEY-ID:
+X-NCP-APIGW-API-KEY:
+
+###37.514219,127.112628,0d17ed4f-cb31-480d-9f2b-f17a2ca41ce7,서울특별시 송파구 송파대로 55,서울특별시 센터
+###37.649621,126.835836,fc5bcff8-dd48-44fa-b36a-80df0262b178,경기도 고양시 덕양구 권율대로 570,경기 북부 센터
+POST http://localhost:19042/api/v1/app/hubRoutes
+Content-Type: application/json
+
+{
+  "fromHubId": "0d17ed4f-cb31-480d-9f2b-f17a2ca41ce7",
+  "toHubId": "fc5bcff8-dd48-44fa-b36a-80df0262b178"
+}

--- a/hub/src/test/java/takeoff/logistics_service/msa/hub/hub/application/service/HubServiceImplTest.java
+++ b/hub/src/test/java/takeoff/logistics_service/msa/hub/hub/application/service/HubServiceImplTest.java
@@ -1,0 +1,164 @@
+package takeoff.logistics_service.msa.hub.hub.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.AdditionalAnswers;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import takeoff.logistics_service.msa.common.exception.BusinessException;
+import takeoff.logistics_service.msa.hub.hub.application.dto.LocationDto;
+import takeoff.logistics_service.msa.hub.hub.application.dto.request.PatchHubRequestDto;
+import takeoff.logistics_service.msa.hub.hub.application.dto.request.PostHubRequestDto;
+import takeoff.logistics_service.msa.hub.hub.application.dto.response.GetHubResponseDto;
+import takeoff.logistics_service.msa.hub.hub.application.dto.response.PatchHubResponseDto;
+import takeoff.logistics_service.msa.hub.hub.application.dto.response.PostHubResponseDto;
+import takeoff.logistics_service.msa.hub.hub.application.exception.HubErrorCode;
+import takeoff.logistics_service.msa.hub.hub.domain.entity.Hub;
+import takeoff.logistics_service.msa.hub.hub.domain.repository.HubRepository;
+
+/**
+ * @author : hanjihoon
+ * @Date : 2025. 03. 18.
+ */
+@DisplayName("HubRoute Service Test")
+@ExtendWith(MockitoExtension.class)
+class HubServiceImplTest {
+
+    @Mock
+    private HubRepository hubRepository;
+
+    @InjectMocks
+    private HubServiceImpl hubserviceImpl;
+
+    @DisplayName("허브 생성 테스트")
+    @Test
+    void create_Hub() {
+        // given
+        LocationDto locationDto = new LocationDto("testLocation", 135.1234, 70.1234);
+        PostHubRequestDto requestDto = new PostHubRequestDto("test", locationDto);
+
+        Hub hub = requestDto.toEntity();
+        PostHubResponseDto expectedResponse = PostHubResponseDto.from(hub);
+
+        BDDMockito.given(hubRepository.save(any(Hub.class)))
+            .willAnswer(AdditionalAnswers.returnsFirstArg());
+
+        // when
+        PostHubResponseDto postHubResponseDto = hubserviceImpl.saveHub(requestDto);
+
+        // then
+        assertThat(postHubResponseDto)
+            .usingRecursiveComparison()  // 객체 비교에 사용
+            .isEqualTo(expectedResponse);
+
+        verify(hubRepository, times(1)).save(any(Hub.class));
+    }
+
+
+    @DisplayName("허브 수정 테스트")
+    @Test
+    void update_Hub() {
+        // given
+        UUID hubId = UUID.randomUUID();
+        LocationDto locationDto = new LocationDto("testLocation", 135.1234, 70.1234);
+        PostHubRequestDto requestDto = new PostHubRequestDto("test", locationDto);
+
+        Hub hub = Hub.builder()
+            .id(hubId)
+            .hubName("test")
+            .location(locationDto.toVo())
+            .build();
+
+        PatchHubRequestDto patchRequestDto = new PatchHubRequestDto("updatedTest");
+
+
+        BDDMockito.given(hubRepository.findById(hubId)).willReturn(Optional.of(hub));
+        BDDMockito.given(hubRepository.save(any(Hub.class)))
+            .willAnswer(AdditionalAnswers.returnsFirstArg());
+
+        hub.modifyHubName(patchRequestDto.hubName());
+
+        hubRepository.save(hub);
+
+
+        PatchHubResponseDto expectedResponse = PatchHubResponseDto.from(hub);
+
+        // when
+        PatchHubResponseDto actualResponse = hubserviceImpl.updateHub(hubId, patchRequestDto);
+
+        // then
+        assertThat(actualResponse)
+            .usingRecursiveComparison()
+            .isEqualTo(expectedResponse);
+
+        verify(hubRepository, times(1)).findById(hubId);
+        verify(hubRepository, times(1)).save(any(Hub.class));
+    }
+
+
+    @DisplayName("허브 조회 테스트")
+    @Test
+    void findByHubId_Hub() {
+        // given
+        UUID hubId = UUID.randomUUID();
+        LocationDto locationDto = new LocationDto("testLocation", 135.1234, 70.1234);
+        PostHubRequestDto requestDto = new PostHubRequestDto("test", locationDto);
+
+        Hub hub = Hub.builder()
+            .id(hubId)
+            .hubName("test")
+            .location(locationDto.toVo())
+            .build();
+
+
+        GetHubResponseDto expectedResponse = GetHubResponseDto.from(hub);
+
+
+        BDDMockito.given(hubRepository.findById(hubId)).willReturn(Optional.of(hub));
+
+        // when
+        GetHubResponseDto actualResponse = hubserviceImpl.findByHubId(hubId);
+
+        // then
+        assertThat(actualResponse)
+            .usingRecursiveComparison()
+            .isEqualTo(expectedResponse);
+
+        verify(hubRepository, times(1)).findById(hubId);
+    }
+    @DisplayName("허브 수정 실패 테스트")
+    @Test
+    void update_Hub_Fail() {
+        // given
+        UUID hubId = UUID.randomUUID();
+        PatchHubRequestDto patchRequestDto = new PatchHubRequestDto("updateTest");
+
+        // 허브가 존재하지 않을 경우 예외가 발생해야 함
+        BDDMockito.given(hubRepository.findById(hubId))
+            .willReturn(Optional.empty());
+
+        // when //then
+        //HubBusinessException은 상속이라 BusinessException으로 검증
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            hubserviceImpl.updateHub(hubId, patchRequestDto);
+        });
+
+
+        assertThat(exception.getErrorCode()).isEqualTo(HubErrorCode.HUB_NOT_FOUND);
+
+
+        verify(hubRepository, times(1)).findById(hubId);
+    }
+
+}

--- a/hub/src/test/java/takeoff/logistics_service/msa/hub/hubroute/application/service/HubRouteServiceImplTest.java
+++ b/hub/src/test/java/takeoff/logistics_service/msa/hub/hubroute/application/service/HubRouteServiceImplTest.java
@@ -1,0 +1,36 @@
+//package takeoff.logistics_service.msa.hub.hubroute.application.service;
+//
+//import static org.junit.jupiter.api.Assertions.*;
+//
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//import takeoff.logistics_service.msa.hub.hubroute.domain.repository.HubRouteRepository;
+//
+///**
+// * @author : hanjihoon
+// * @Date : 2025. 03. 18.
+// */
+//@DisplayName("HubRoute Service Test")
+//@ExtendWith(MockitoExtension.class)
+//class HubRouteServiceImplTest {
+//
+//    @Mock
+//    private HubRouteRepository hubRouteRepository;
+//
+//    @InjectMocks
+//    private HubRouteService hubRouteService;
+//
+//    @DisplayName("")
+//    @Test
+//    void () {
+//        // given
+//
+//        // when
+//
+//        // then
+//    }
+//
+//}


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #40 

## 변경 타입
- [x] 신규 기능 추가/수정


## 변경 내용
- **as-is**
  - 허브 라우트에서 허브와 허브간 이동경로 거리와 시간 계산로직 추가해야함

- **to-be**(변경 후 설명을 여기에 작성)

  - [x] NAVER API 연동
  - [x] 거리, 시간 계산 및 경로 저장 로직 구현


## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.


## 코멘트
HubRoute 쪽 http 파일을 확인하면 허브 아이디 2개 적는데 2개 적으면 feign으로 요청을 보내 허브와 허브간 이동거리를 계산하고 저장합니다.
오늘중으로 알고리즘을 통해 출발 허브부터 도착허브까지의 경로를 시간과 거리를 포함해 보내는 기능 추가 예정입니다.
